### PR TITLE
Change internal server error -> unauthorized

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,8 +125,8 @@ func main() {
 				i := sort.SearchStrings(claims.Groups, group)
 
 				if (i >= len(claims.Groups)) || (claims.Groups[i] != group) {
-					http.Error(w, http.StatusText(http.StatusInternalServerError),
-						http.StatusInternalServerError)
+					http.Error(w, http.StatusText(http.StatusUnauthorized),
+						http.StatusUnauthorized)
 					return
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -191,8 +191,8 @@ func main() {
 				i := sort.SearchStrings(claims.Groups, group)
 
 				if (i >= len(claims.Groups)) || (claims.Groups[i] != group) {
-					http.Error(w, http.StatusText(http.StatusInternalServerError),
-						http.StatusInternalServerError)
+					http.Error(w, http.StatusText(http.StatusUnauthorized),
+						http.StatusUnauthorized)
 					return
 				}
 			}


### PR DESCRIPTION
If you're not in the group, `traefik-dex-auth` will currently return an Internal Server Error.

This changes it to `Unauthorized`.